### PR TITLE
Use a non-intrusive API to set resolution

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,7 +24,9 @@
         android:name="android.permission.ACCESS_CACHE_FILESYSTEM"
         tools:ignore="ProtectedPermissions" />
     <uses-permission android:name="com.android.alarm.permission.SET_ALARM" />
-    <uses-permission android:name="android.permission.WRITE_SYSTEM_SETTINGS" />
+    <uses-permission
+        android:name="android.permission.WRITE_SECURE_SETTINGS"
+        tools:ignore="ProtectedPermissions" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -42,7 +42,8 @@
             android:permission="android.permission.BIND_JOB_SERVICE"
             android:exported="true" />
             
-        <activity android:name=".activities.Screen_Resolution">
+        <activity android:name=".activities.Screen_Resolution"
+            android:theme="@style/SystemPreferenceTheme">
             <intent-filter>
                 <action android:name="com.android.settings.action.IA_SETTINGS" />
             </intent-filter>

--- a/app/src/main/java/de/dlyt/yanndroid/freshapp/activities/Screen_Resolution.java
+++ b/app/src/main/java/de/dlyt/yanndroid/freshapp/activities/Screen_Resolution.java
@@ -2,21 +2,25 @@ package de.dlyt.yanndroid.freshapp.activities;
 
 import androidx.appcompat.app.AppCompatActivity;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.content.Context;
 import android.content.SharedPreferences;
 import android.graphics.Typeface;
 import android.os.Bundle;
+import android.provider.Settings;
+import android.util.Log;
+import android.view.Display;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.RadioGroup;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.google.android.material.appbar.AppBarLayout;
 import com.google.android.material.button.MaterialButton;
 import com.google.android.material.radiobutton.MaterialRadioButton;
 
-import java.util.HashMap;
+import java.util.Scanner;
 
 import de.dlyt.yanndroid.freshapp.R;
 
@@ -26,13 +30,26 @@ public class Screen_Resolution extends AppCompatActivity {
 
     public static String PREF_NAME = "ScreenResolutionSettings";
     public static String SCREEN_RESOLUTION = "device_screen_resolution";
+    public static String RESTRICTED_API = "device_restricted_api";
 
     int resolution;
+    int api_setting;
+    int default_api_setting;
+    int current_resolution;
 
+    private Context mContext;
     private SharedPreferences sharedPreferences;
+
+    private void checkDefaultApiSetting() {
+        try {   
+            default_api_setting = Settings.Global.getInt(mContext.getContentResolver(), "hidden_api_policy");
+            sharedPreferences.edit().putInt(RESTRICTED_API, default_api_setting).commit();
+        } catch (Exception e) { /* Fail */ };
+    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        mContext = this;
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_screen__resolution);
 
@@ -40,9 +57,13 @@ public class Screen_Resolution extends AppCompatActivity {
         settilte("Screen resolution");
 
         sharedPreferences = getSharedPreferences(PREF_NAME, Activity.MODE_PRIVATE);
+        checkDefaultApiSetting();
+
         resolution = sharedPreferences.getInt(SCREEN_RESOLUTION, R.id.resolution_high);
+        current_resolution = sharedPreferences.getInt(SCREEN_RESOLUTION, R.id.resolution_high);
 
         RadioGroup resolution_radiogroup = findViewById(R.id.resolution_radiogroup);
+        MaterialButton resolution_apply = findViewById(R.id.resolution_apply);
         MaterialRadioButton resolution_low = findViewById(R.id.resolution_low);
         MaterialRadioButton resolution_medium = findViewById(R.id.resolution_medium);
         MaterialRadioButton resolution_high = findViewById(R.id.resolution_high);
@@ -57,7 +78,10 @@ public class Screen_Resolution extends AppCompatActivity {
                 resolution_high.setTypeface(Typeface.DEFAULT);
                 MaterialRadioButton resolution_tosetBold = findViewById(checkedId);
                 resolution_tosetBold.setTypeface(Typeface.DEFAULT_BOLD);
+
+                resolution_apply.setEnabled(current_resolution != checkedId);
                 resolution = checkedId;
+
                 switch (checkedId){
                     case R.id.resolution_low:
                         resolution_summary.setText(R.string.low_resolution_summary);
@@ -71,36 +95,105 @@ public class Screen_Resolution extends AppCompatActivity {
                 }
             }
         });
+
         resolution_radiogroup.check(resolution);
+        resolution_apply.setEnabled(false);
 
-
-        MaterialButton resolution_apply = findViewById(R.id.resolution_apply);
         resolution_apply.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 sharedPreferences.edit().putInt(SCREEN_RESOLUTION, resolution).commit();
-                switch (resolution){
-                    case R.id.resolution_low:
-                        setResolution(getString(R.string.low_resolution_value), getString(R.string.low_resolution_density));
-                        break;
-                    case R.id.resolution_medium:
-                        setResolution(getString(R.string.medium_resolution_value), getString(R.string.medium_resolution_density));
-                        break;
-                    case R.id.resolution_high:
-                        setResolution(getString(R.string.high_resolution_value), getString(R.string.high_resolution_density));
-                        break;
+                resolution_apply.setEnabled(false);
+                current_resolution = resolution;
+                checkDefaultApiSetting(); // Re-check default value before setting
+                try {
+                        setBypassBlacklist(mContext, true);
+
+                        switch (resolution) {
+                            case R.id.resolution_low:
+                                setResolution(getString(R.string.low_resolution_value), getString(R.string.low_resolution_density));
+                                break;
+                            case R.id.resolution_medium:
+                                setResolution(getString(R.string.medium_resolution_value), getString(R.string.medium_resolution_density));
+                                break;
+                            case R.id.resolution_high:
+                                setResolution("reset", "reset");
+                                break;
+                        }
+
+                        // Re-lock APIs for security
+                        setBypassBlacklist(mContext, false);
+
+                    } catch (Exception e) {
+                        Log.e("ScreenResolutionService", "Fail!", e);
+                    }
                 }
-            }
         });
 
     }
 
-    public void setResolution(String resolution, String density){
-        shell("pm grant de.dlyt.yanndroid.freshapp android.permission.WRITE_SECURE_SETTINGS", true);
-        shell("su -c wm size "+ resolution, true);
-        shell("su -c wm density "+ density, true);
-        shell("su -c settings put secure sysui_rounded_size 1", true);
-        shell("su -c settings put secure sysui_rounded_size 0", true);
+    public static void setBypassBlacklist(Context context, boolean bool) {
+        /* List of Global settings that allow blacklisted APIs to be called */
+        String[] blacklistGlobalSettings = {
+                "hidden_api_policy",
+                "hidden_api_policy_pre_p_apps",
+                "hidden_api_policy_p_apps"
+        };
+
+        SharedPreferences sharedPreferencesBp = context.getSharedPreferences(PREF_NAME, Activity.MODE_PRIVATE);
+        int default_restricted_api_setting = sharedPreferencesBp.getInt(RESTRICTED_API, 0);
+
+        if (bool) {
+            for (String setting : blacklistGlobalSettings) {
+                Settings.Global.putInt(context.getContentResolver(), setting, 1);
+            }
+        } else {
+            for (String setting : blacklistGlobalSettings) {
+                Settings.Global.putInt(context.getContentResolver(), setting, default_restricted_api_setting);
+            }
+        }
+    }
+
+    @SuppressLint("PrivateApi")
+    private static Object getWindowManagerService() throws Exception {
+        return Class.forName("android.view.WindowManagerGlobal")
+                .getMethod("getWindowManagerService")
+                .invoke(null);
+    }
+
+    @SuppressLint("PrivateApi")
+    private static void setResolution(String wmSize, String wmDensity) throws Exception {
+        final int USER_CURRENT_OR_SELF = -3;
+
+        if (wmSize.equals("reset")) {
+            Class.forName("android.view.IWindowManager")
+                    .getMethod("clearForcedDisplaySize", int.class)
+                    .invoke(getWindowManagerService(), Display.DEFAULT_DISPLAY);
+        } else {
+            Scanner scanner = new Scanner(wmSize);
+            scanner.useDelimiter("x");
+
+            int width = scanner.nextInt();
+            int height = scanner.nextInt();
+
+            scanner.close();
+
+            Class.forName("android.view.IWindowManager")
+                    .getMethod("setForcedDisplaySize", int.class, int.class, int.class)
+                    .invoke(getWindowManagerService(), Display.DEFAULT_DISPLAY, width, height);
+        }
+
+        if(wmDensity.equals("reset")) {
+            Class.forName("android.view.IWindowManager")
+                    .getMethod("clearForcedDisplayDensityForUser", int.class, int.class)
+                    .invoke(getWindowManagerService(), Display.DEFAULT_DISPLAY, USER_CURRENT_OR_SELF);
+        } else {
+            int density = Integer.parseInt(wmDensity);
+
+            Class.forName("android.view.IWindowManager")
+                    .getMethod("setForcedDisplayDensityForUser", int.class, int.class, int.class)
+                    .invoke(getWindowManagerService(), Display.DEFAULT_DISPLAY, density, USER_CURRENT_OR_SELF);
+        }
     }
 
     public void initToolbar() {

--- a/app/src/main/res/color/sesl_btn_color_state.xml
+++ b/app/src/main/res/color/sesl_btn_color_state.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false"
+        android:color="@color/sesl_btn_background_color"  />
+    <item android:color="@color/sesl_control_activated_color" />
+</selector>

--- a/app/src/main/res/color/sesl_btn_color_state.xml
+++ b/app/src/main/res/color/sesl_btn_color_state.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_enabled="false"
-        android:color="@color/sesl_btn_background_color"  />
+        android:color="@color/sesl_control_activated_color" android:alpha="0.4" />
     <item android:color="@color/sesl_control_activated_color" />
 </selector>

--- a/app/src/main/res/color/sesl_preference_btn_color_state.xml
+++ b/app/src/main/res/color/sesl_preference_btn_color_state.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false"
+        android:color="@color/sesl_btn_background_color"  />
+    <item android:color="@color/sesl_default_primary_color" />
+</selector>

--- a/app/src/main/res/color/sesl_preference_btn_color_state.xml
+++ b/app/src/main/res/color/sesl_preference_btn_color_state.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_enabled="false"
-        android:color="@color/sesl_btn_background_color"  />
+        android:color="@color/sesl_default_primary_color" android:alpha="0.4" />
     <item android:color="@color/sesl_default_primary_color" />
 </selector>

--- a/app/src/main/res/layout/activity_screen__resolution.xml
+++ b/app/src/main/res/layout/activity_screen__resolution.xml
@@ -52,7 +52,7 @@
                                 <LinearLayout
                                     android:layout_width="fill_parent"
                                     android:layout_height="wrap_content"
-                                    android:layout_marginLeft="20.0dip"
+                                    android:layout_marginLeft="24.0dip"
                                     android:layout_marginTop="24.0dip"
                                     android:layout_marginRight="20.0dip"
                                     android:orientation="horizontal">
@@ -116,8 +116,11 @@
                                 android:layout_height="wrap_content"
                                 android:layout_marginHorizontal="@dimen/sec_widget_body_text_padding_start_end"
                                 android:layout_marginTop="@dimen/sec_widget_preference_unclickable_margin_top"
+                                android:textStyle="bold"
+                                android:textSize="16.0sp"
+                                android:fontFamily="sec-roboto-light"
                                 android:text="@string/screen_resolution_desc_summary"
-                                android:textColor="@color/item_color" />
+                                android:textColor="@color/sec_display_resolution_help_desc_text_color" />
                         </LinearLayout>
 
                         <com.google.android.material.card.MaterialCardView
@@ -199,12 +202,15 @@
                                 android:layout_marginHorizontal="@dimen/sec_widget_body_text_padding_start_end"
                                 android:layout_marginTop="@dimen/sec_widget_preference_unclickable_margin_top"
                                 android:text="summary"
-                                android:textColor="@color/item_color" />
+                                android:textStyle="bold"
+                                android:textSize="15.0dip"
+                                android:fontFamily="sec-roboto-light"
+                                android:textColor="@color/sec_display_resolution_desc_text_color" />
                         </LinearLayout>
 
                         <com.google.android.material.button.MaterialButton
                             android:id="@+id/resolution_apply"
-                            style="@style/ButtonStyle.Invert"
+                            style="@style/ButtonStyle_PreferenceSetting"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:layout_marginHorizontal="100dp"

--- a/app/src/main/res/layout/activity_screen__resolution.xml
+++ b/app/src/main/res/layout/activity_screen__resolution.xml
@@ -116,8 +116,9 @@
                                 android:layout_height="wrap_content"
                                 android:layout_marginHorizontal="@dimen/sec_widget_body_text_padding_start_end"
                                 android:layout_marginTop="@dimen/sec_widget_preference_unclickable_margin_top"
-                                android:textStyle="bold"
-                                android:textSize="16.0sp"
+                                android:layout_marginBottom="10.0dip"
+                                android:textSize="15.0sp"
+                                android:lineSpacingExtra="4.0sp"
                                 android:fontFamily="sec-roboto-light"
                                 android:text="@string/screen_resolution_desc_summary"
                                 android:textColor="@color/sec_display_resolution_help_desc_text_color" />

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -15,8 +15,9 @@
     <color name="item_color">#fff2f2f2</color>
 
     <!--Sesl-->
-    <color name="divider_color">#42fafafa</color>
+    <color name="divider_color">#2afafafa</color>
 
+    <color name="sesl_btn_background_color">#2bfafafa</color>
 
     <!--Switch-->
     <color name="sesl_switch_thumb_off_disabled_color">#ff828282</color>
@@ -39,5 +40,8 @@
     <color name="button_background_color">#4d555555</color>
     <color name="drawer_dim_color">#cc000000</color>
     <color name="ota_changelog_text_color">@color/sesl_white</color>
+
+    <color name="sec_display_resolution_desc_text_color">#ff7a7a7a</color>
+    <color name="sec_display_resolution_help_desc_text_color">#fffafafa</color>
 
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -12,6 +12,8 @@
     <color name="sesl_primary_dark_color">#ffbd7800</color>
     <color name="sesl_control_color_normal">#4df3a425</color>
 
+    <color name="sesl_default_primary_color">#ff0381fe</color>
+    <color name="sesl_default_secondary_color">#ff0072de</color>
 
     <color name="sesl_control_normal_color">#cc8f8f8f</color>
 
@@ -40,9 +42,10 @@
     <color name="sesl_control_activated_color">@color/sesl_secondary_color</color>
     <color name="sesl_white">#fffafafa</color>
     <color name="sesl_black">#ff252525</color>
-    <color name="divider_color">#ff979797</color>
+    <color name="divider_color">#8a979797</color>
     <color name="sesl_thumb_control_color_activated">@color/sesl_primary_color</color>
 
+    <color name="sesl_btn_background_color">#0f000000</color>
 
     <!--ProgressBar-->
     <color name="sesl_loading_progress_color1">#ff06b485</color>
@@ -105,6 +108,9 @@
     <color name="ota_changelog_text_color">@color/sesl_black</color>
     <color name="system_settings_plugin_icon_bg_color">#ff7882ff</color>
     <color name="system_notification_color">#fff3a425</color>
+
+    <color name="sec_display_resolution_desc_text_color">#ff7a7a7a</color>
+    <color name="sec_display_resolution_help_desc_text_color">#ff252525</color>
 
 
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -24,6 +24,26 @@
 
     </style>
 
+    <style name="SystemPreference">
+        <item name="colorAccent">@color/sesl_default_primary_color</item>
+        <item name="colorBackgroundFloating">@color/sesl_background_floating</item>
+        <item name="colorControlActivated">@color/sesl_default_primary_color</item>
+        <item name="colorControlHighlight">@color/sesl_ripple_color</item>
+        <item name="colorControlNormal">@color/sesl_control_normal_color</item>
+        <item name="colorError">@color/sesl_error_color</item>
+        <item name="colorPrimary">@color/sesl_default_primary_color</item>
+        <item name="colorSecondary">@color/sesl_default_secondary_color</item>
+        <item name="colorPrimaryDark">@color/sesl_default_secondary_color</item>
+
+        <item name="checkboxStyle">@style/CheckBoxStyle</item>
+        <item name="materialCardViewStyle">@style/CardViewStyle</item>
+        <item name="switchStyle">@style/SwitchStyle</item>
+        <item name="materialButtonStyle">@style/ButtonStyle</item>
+        <item name="radioButtonStyle">@style/RadioButtonStyle</item>
+        <item name="seslSwitchBarStyle">@style/Base.Widget.AppCompat.SeslSwitchBar</item>
+        <item name="seekBarStyle">@style/SeekBarStyle</item>
+    </style>
+
 
     <!--ProgressBar-->
     <style name="ProgressBarStyle.Horizontal.Large" parent="@android:style/Widget.ProgressBar.Horizontal">
@@ -113,17 +133,25 @@
         <item name="rippleColor">@color/button_ripple_color</item>
         <item name="cornerRadius">26dp</item>
         <item name="android:textSize">16sp</item>
+        <item name="android:padding">12dip</item>
         <item name="android:textColor">@color/sesl_control_activated_color</item>
+        <item name="android:textStyle">bold</item>
+        <item name="fontFamily">sec-roboto-light</item>
     </style>
 
     <style name="ButtonStyle.Invert">
-        <item name="android:backgroundTint">@color/sesl_control_activated_color</item>
+        <item name="android:backgroundTint">@color/sesl_btn_color_state</item>
         <item name="android:textColor">@color/white</item>
     </style>
 
     <style name="ButtonStyle.Invert.Secondary">
         <item name="android:backgroundTint">@color/button_background_color</item>
         <item name="android:textColor">@color/item_color</item>
+    </style>
+
+    <style name="ButtonStyle_PreferenceSetting" parent="@style/ButtonStyle.Invert">
+        <item name="android:backgroundTint">@color/sesl_preference_btn_color_state</item>
+        <item name="android:padding">8dip</item>
     </style>
 
 

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -10,4 +10,8 @@
         <item name="android:theme">@style/Main</item>
 
     </style>
+
+    <style name="SystemPreferenceTheme" parent="@style/AppTheme">
+        <item name="android:theme">@style/SystemPreference</item>
+    </style>
 </resources>


### PR DESCRIPTION
This uses an undocumented `android.view.IWindowManager` API that forces both screen resolution and density, with a syntax that is very similar to the one that used root.

Since these APIs have been blocked starting Android 9, we set setting flags to temporarily allow the app to use them; we disable those after for security. We also store the default value so we can keep them on if user *intentionally* enabled those APIs (i.e. for another app).

API is a derivative of works by @farmerbb and @tytydraco. Please attribute them.

---

This also makes the ScreenResolution activity more closely match the stock counterpart, using resources from the Settings app.