### PR TITLE
Directories for downloads

### DIFF
--- a/app/src/main/java/de/dlyt/yanndroid/freshapp/download/DownloadAddon.java
+++ b/app/src/main/java/de/dlyt/yanndroid/freshapp/download/DownloadAddon.java
@@ -44,8 +44,10 @@ public class DownloadAddon implements Constants {
         request.setVisibleInDownloadsUi(true);
         request.setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE);
         fileName = fileName + ".zip";
-        //request.setDestinationInExternalPublicDir(INSTALL_AFTER_FLASH_DIR_ADDON, fileName); //todo: custom path... is crashing, reason: java.lang.IllegalStateException: Not one of standard directories
-        request.setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, fileName);
+
+        // Because of Scoped Storage, we can only download into public directories.
+        // Directory is '/storage/emulated/0/Download/Fresh'
+        request.setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, OTA_DOWNLOAD_DIR+fileName);
 
         DownloadManager downloadManager = (DownloadManager) context.getSystemService(Context
                 .DOWNLOAD_SERVICE);

--- a/app/src/main/java/de/dlyt/yanndroid/freshapp/download/DownloadRom.java
+++ b/app/src/main/java/de/dlyt/yanndroid/freshapp/download/DownloadRom.java
@@ -52,8 +52,10 @@ public class DownloadRom implements Constants {
 
         request.setVisibleInDownloadsUi(true);
         request.setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE);
-        //request.setDestinationInExternalPublicDir(OTA_DOWNLOAD_DIR, fileName);  //todo: custom path... is crashing, reason: java.lang.IllegalStateException: Not one of standard directories
-        request.setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, fileName);
+
+        // Because of Scoped Storage, we can only download into public directories.
+        // Directory is '/storage/emulated/0/Download/Fresh'
+        request.setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, OTA_DOWNLOAD_DIR+fileName);
 
         // Delete any existing files
         Utils.deleteFile(file);

--- a/app/src/main/java/de/dlyt/yanndroid/freshapp/utils/Constants.java
+++ b/app/src/main/java/de/dlyt/yanndroid/freshapp/utils/Constants.java
@@ -25,7 +25,7 @@ public interface Constants {
 
     // Storage
     String SD_CARD = Environment.getExternalStorageDirectory().getAbsolutePath();
-    String OTA_DOWNLOAD_DIR = "Updates";
+    String OTA_DOWNLOAD_DIR = "/Fresh/";
     String INSTALL_AFTER_FLASH_DIR = "InstallAfterFlash";
     String INSTALL_AFTER_FLASH_DIR_ADDON = "/Updates/InstallAfterFlash";
 


### PR DESCRIPTION
Because the app targets 11 (> Q), downloads can only be put in standard Android directories.

> For applications targeting Build.VERSION_CODES.Q or above, WRITE_EXTERNAL_STORAGE permission is not needed and the dirType must be one of the known public directories like Environment#DIRECTORY_DOWNLOADS, Environment#DIRECTORY_PICTURES, Environment#DIRECTORY_MOVIES, etc.

https://developer.android.com/reference/android/app/DownloadManager.Request#setDestinationInExternalPublicDir(java.lang.String,%20java.lang.String)